### PR TITLE
feat: defaul cmd can now be a function that returns a cmd string

### DIFF
--- a/lua/compile/init.lua
+++ b/lua/compile/init.lua
@@ -26,9 +26,13 @@ end
 
 --- Compiles the project and captures errors in the terminal.
 --- This is the core function for running the build process. It takes an optional command string, falls back to the default `make -k` command, and then initiates the compilation within the integrated terminal.
----@param cmd? string The command to execute. Defaults to `compile.opts.cmds.default`.
+---@param cmd? string|function The command to execute. Defaults to `compile.opts.cmds.default`.
 function compile.compile(cmd)
 	cmd = cmd or compile.opts.cmds.default
+	if type(cmd) == 'function' then
+		cmd = cmd()
+	end
+
 	compile.utils.enter_wrapper(function()
 		compile.term.destroy()
 		if compile.highlight.has_warnings() then

--- a/lua/compile/opts.lua
+++ b/lua/compile/opts.lua
@@ -55,26 +55,16 @@ return {
 	keys = {
 		global = {
 			["n"] = {
-				["<localleader>cc"] = "require('compile').compile()",
 				["<localleader>cn"] = "require('compile').next_error()",
 				["<localleader>cp"] = "require('compile').prev_error()",
-				["<localleader>cl"] = "require('compile').last_error()",
-				["<localleader>cf"] = "require('compile').first_error()",
-				["<localleader>cj"] = "require('compile').term.jump_to()",
 			},
 		},
 		term = {
 			global = {
-				["n"] = {
-					["<localleader>cr"] = "require('compile').clear()",
-					["<localleader>cq"] = "require('compile').destroy()",
-				},
+				["n"] = {},
 			},
 			buffer = {
 				["n"] = {
-					["r"] = "require('compile').clear()",
-					["c"] = "require('compile').compile()",
-					["q"] = "require('compile').destroy()",
 					["n"] = "require('compile').next_error()",
 					["p"] = "require('compile').prev_error()",
 					["0"] = "require('compile').first_error()",
@@ -83,7 +73,6 @@ return {
 				},
 				["t"] = {
 					["<CR>"] = "require('compile').clear_hl()",
-					["<C-j>"] = "require('compile.term').send_cmd('')",
 				},
 			},
 		},


### PR DESCRIPTION
this simple change makes it possible to define custom functions for default cmds. as an example:
```lua
default = function()
	local relative_path = ' ' .. vim.fn.expand('%:.')
	local binary_path = ' ' .. vim.fn.expand('%:.:r')

	local commands = {
		python = 'python' .. relative_path,
		c = 'gcc -o' .. binary_path .. relative_path,
	}

	return commands[vim.bo.filetype]
end,
```
<img width="1088" height="115" alt="image" src="https://github.com/user-attachments/assets/9cb499fa-ebd4-445c-9a12-ce1c3b224cf7" />
